### PR TITLE
add @ts-ignore to CloneNodeOptions#factory for TypeScript v3

### DIFF
--- a/src/clone-node/clone-node-options.ts
+++ b/src/clone-node/clone-node-options.ts
@@ -27,6 +27,7 @@ export interface CloneNodeOptions<T extends MetaNode = MetaNode> {
 	hook: CloneNodeHookFactory<T>;
 	finalize: CloneNodeFinalizerCallback<T>;
 	typescript: typeof TS;
+	// @ts-ignore
 	factory: TS.NodeFactory;
 	setParents: boolean;
 	setOriginalNodes: boolean;


### PR DESCRIPTION
In TypeScript v3 environment, a compile error occurs because there is no ts.NodeFactory type.

![image](https://user-images.githubusercontent.com/12995573/89603913-16af1d80-d8a5-11ea-84f6-ec32176e37a4.png)
