### PR TITLE
Fix @see handling with TypeScript 4.1

### DIFF
--- a/src/clone-node/clone-js-doc-see-tag.ts
+++ b/src/clone-node/clone-js-doc-see-tag.ts
@@ -1,0 +1,27 @@
+import {TS} from "./type/ts";
+import {CloneNodeVisitorOptions} from "./clone-node-options";
+import {Mutable} from "./util/mutable";
+
+export function cloneJsDocSeeTag(node: Mutable<TS.JSDocSeeTag>, options: CloneNodeVisitorOptions<TS.JSDocSeeTag>): TS.JSDocSeeTag {
+	if ("factory" in options.typescript) {
+		return v4Strategy(node, options);
+	}
+
+	throw new Error('No strategy for cloning JSDocSeeTag in TypeScript v3');
+}
+
+/**
+ * Relevant to TypeScript v4.x
+ */
+function v4Strategy(node: Mutable<TS.JSDocSeeTag>, options: CloneNodeVisitorOptions<TS.JSDocSeeTag>): TS.JSDocSeeTag {
+	const baseNode = options.factory.createJSDocSeeTag(
+		options.hook("tagName", options.nextNode(node.tagName), node.tagName),
+		// NOTE: do we want to wrap around `node.name`, which is a
+		// `JSDocNameReference`?
+		options.hook("name", node.name, node.name),
+		options.hook("comment", node.comment, node.comment)
+	) as Mutable<TS.JSDocSeeTag>;
+	baseNode.flags = options.hook("flags", (node.flags |= 8), (node.flags |= 8));
+
+	return baseNode;
+}

--- a/src/clone-node/clone-node.ts
+++ b/src/clone-node/clone-node.ts
@@ -218,6 +218,8 @@ import {payload} from "./util/payload";
 import {cloneNamespaceExport} from "./clone-namespace-export";
 import {isJsDocReadonlyTag} from "./util/is-js-doc-readonly-tag";
 import {cloneJsDocReadonlyTag} from "./clone-js-doc-readonly-tag";
+import {isJsDocSeeTag} from "./util/is-js-doc-see-tag";
+import {cloneJsDocSeeTag} from "./clone-js-doc-see-tag";
 import {isJsDocPrivateTag} from "./util/is-js-doc-private-tag";
 import {cloneJsDocPrivateTag} from "./clone-js-doc-private-tag";
 import {isJsDocProtectedTag} from "./util/is-js-doc-protected-tag";
@@ -1246,6 +1248,11 @@ function executeCloneNode<T extends MetaNode>(node: T | undefined, options: Clon
 	// Handle the Node
 	else if (isJsDocReadonlyTag(node, options.typescript)) {
 		return cloneJsDocReadonlyTag(node, (options as unknown) as CloneNodeVisitorOptions<TS.JSDocReadonlyTag>);
+	}
+
+	// Handle the Node
+	else if (isJsDocSeeTag(node, options.typescript)) {
+		return cloneJsDocSeeTag(node, (options as unknown) as CloneNodeVisitorOptions<TS.JSDocSeeTag>);
 	}
 
 	// Handle the Node

--- a/src/clone-node/util/is-js-doc-see-tag.ts
+++ b/src/clone-node/util/is-js-doc-see-tag.ts
@@ -1,0 +1,14 @@
+import {TS} from "../type/ts";
+import {MetaNode} from "../type/meta-node";
+
+/**
+ * Returns true if the given Node is a JSDocSeeTag
+ */
+export function isJsDocSeeTag(node: MetaNode, typescript: typeof TS): node is TS.JSDocSeeTag {
+	// TypeScript 4.x
+	if (("isJSDocSeeTag" in typescript) as never) {
+		// @ts-expect-error https://github.com/microsoft/TypeScript/issues/41822
+		return typescript.isJSDocSeeTag(node);
+	}
+	return node.kind === typescript.SyntaxKind.JSDocSeeTag;
+}

--- a/test/comment.test.ts
+++ b/test/comment.test.ts
@@ -171,3 +171,16 @@ test("Clones comments correctly. #12", (t, {typescript}) => {
 
 	t.deepEqual(formatCode(cloneAsText(text, {typescript})), formatCode(text));
 });
+
+test("Clones comments correctly. #13", (t, {typescript}) => {
+	const text = `\
+	interface Foo {
+	}
+	/**
+	 * @see https://example.com/
+	 */
+	 function foo (): void {}
+`;
+
+	t.deepEqual(formatCode(cloneAsText(text, {typescript})), formatCode(text));
+});

--- a/test/comment.test.ts
+++ b/test/comment.test.ts
@@ -184,3 +184,16 @@ test("Clones comments correctly. #13", (t, {typescript}) => {
 
 	t.deepEqual(formatCode(cloneAsText(text, {typescript})), formatCode(text));
 });
+
+test("Clones comments correctly. #14", (t, {typescript}) => {
+	const text = `\
+	interface Foo {
+	}
+	/**
+	 * @example foo();
+	 */
+	 function foo (): void {}
+`;
+
+	t.deepEqual(formatCode(cloneAsText(text, {typescript})), formatCode(text));
+});


### PR DESCRIPTION
I added a test for `@see` (and also `@example`, which works fine, but lacked a test).

Without further code changes, this resulted in the following error, upon running `npm test`:

```
Error thrown in test:

  TypeError {
    message: 'Could not handle Node of kind: \'JSDocSeeTag\'',
  }
```

This appears to only affect TypeScript 4.1.2, not TypeScript 4.0.3.

As a separate commit, I did my best to copy the functionality of the `@readonly` tag, which appears to fix things for me locally.